### PR TITLE
Remove inst authors from hep outputs for intitution

### DIFF
--- a/code/queries/heps_outputs.js
+++ b/code/queries/heps_outputs.js
@@ -258,11 +258,11 @@ CREATE OR REPLACE TABLE \`${project}.${dataset}.heps_outputs${version}\` AS (
     doi_all.oa                           AS oa,
     doi_all.institutions                 AS institutions,
     alex.authors                         AS authors,
-    STRUCT(
+    ARRAY[STRUCT(
         NULL AS name,
         NULL AS orcid, 
         NULL AS raw_affiliation
-    ) AS inst_authors,
+    )] AS inst_authors,
     ries.year                            AS year,
     ries.citations                       AS citations,
     assignments.apportionment            AS apportionment,

--- a/code/tasks.js
+++ b/code/tasks.js
@@ -206,8 +206,8 @@ async function export_hep_outputs(config) {
   for (hep of config.institutional_hep_codes) {
     console.log(`Exporting institutional HEP outputs: ${hep}`);
     sql = output_hep_data.compile({
-      for_table: `${config.project}.ries_fors_${hep}_institutional_outputs.heps_outputs${config.version}`,
-      foe_table: `${config.project}.ries_foes_${hep}_institutional_outputs.heps_outputs${config.version}`,
+      for_table: `${config.project}.ries_fors_${hep}.heps_outputs${config.version}`,
+      foe_table: `${config.project}.ries_foes_${hep}.heps_outputs${config.version}`,
     });
     await process_query_stream(bq_link.bq.createQueryStream(sql), query_writer);
     fs.writeFileSync(path_config.export_output.inst_queries[hep], sql);


### PR DESCRIPTION
Alters the insitutional hep outputs sql to nullify the institutional authors.

Also changes the source tables to the ries project datastet, rather than that generated in the export_hep step
