### PR TITLE
HEP output writing update

### DIFF
--- a/code/tasks.js
+++ b/code/tasks.js
@@ -190,8 +190,8 @@ async function export_hep_outputs(config) {
   const query_writer = new SQLBatchWriter({
     dir: "data",
     file_pre: path_config.export_output.sql_file,
-    max_rows_per_insert: 10,
-    max_inserts_per_file: 5000,
+    max_rows_per_insert: 5,
+    max_inserts_per_file: 10000,
   });
 
   console.log("Exporting automatic HEP outputs");


### PR DESCRIPTION
Cloudflare D1 is unhappy with our data uploads. It will reject some uploads as the sql statemnt is too long. Apparently the maximum statement length is 1MB. Ours are far below that but it complains anyway, so I reduced the length and increased the number of statements accordingly. 